### PR TITLE
Add warning about importing/injecting TourService

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -18,12 +18,14 @@
         <h2 id="about">About</h2>
 
         <p>This is a product tour library built with Angular (2+). It's inspired by
-          <a href="http://benmarch.github.io/angular-ui-tour">angular-ui-tour</a>.
+            <a href="http://benmarch.github.io/angular-ui-tour">angular-ui-tour</a>.
         </p>
 
         <h2 id="implementation">Implementations</h2>
 
-        <p>The core functionality of this tour package is implemented in <code>@ngx-tour/core</code> (<a href="https://badge.fury.io/js/%40ngx-tour%2Fcore"><img src="https://badge.fury.io/js/%40ngx-tour%2Fcore.svg" alt="npm version" height="18"></a>).</p>
+        <p>The core functionality of this tour package is implemented in <code>@ngx-tour/core</code> (<a
+                href="https://badge.fury.io/js/%40ngx-tour%2Fcore"><img
+                    src="https://badge.fury.io/js/%40ngx-tour%2Fcore.svg" alt="npm version" height="18"></a>).</p>
 
         <p>There are multiple implementations of the <code>@ngx-tour</code>:</p>
 
@@ -34,5 +36,12 @@
             <li><a [routerLink]="['/ngx-popper']">@ngx-tour/ngx-popper</a></li>
             <li><a [routerLink]="['/console']">@ngx-tour/console</a></li>
         </ul>
+
+        <div class="alert alert-warning" role="alert">
+            <i>NOTE: </i><b>TourService</b> is exported by <b>@ngx-tour/core</b> and each of the implementations export
+            a more specialized version. When using <b>@ngx-tour</b> across multiple modules, ensure that your imports
+            all reference the implementation-specific <b>TourService</b> or you will get two different instances of
+            <b>TourService</b> injected and each will have a different configuration/steps/etc...
+        </div>
     </main>
 </div>


### PR DESCRIPTION
I added @ngx-tour to a project that has several lazy-loaded modules.  I first had a minor issue ensuring TourService got instantiated once (`imports: [..., TourNgxBootstrapModule.forRoot()]` at the app module, `imports: [..., TourNgxBootstrapModule]` for all other modules.

But then I ran into an issue where I added an import to `TourService` from VS Code, in one component it was like this:

```
import { TourService } from '@ngx-tour/ngx-bootstrap';
```

and in another component it was like this:

```
import { TourService } from '@ngx-tour/core';
```

It took me a bit to track down what had happened, but essentially this meant that the TourService wasn't really a singleton like expected/required so one TourService had all of the steps and initialization and events firing, and the other one had no steps, no currentStep, no events, etc...

So I added a warning to the documentation app/sample.

If you'd like to reject this PR that's completely fine.  I just wanted to get this documented somewhere and I would have created an issue for it but Issues haven't been enabled on this repository since the fork (You can enable Issues in the Settings if you'd like).  Also, thanks for picking up maintenance on this library, it was super-easy to integrate into my angular app.

Signed-off-by: Jon Stelly <967068+jonstelly@users.noreply.github.com>